### PR TITLE
Updated WMM_EPOCH constant

### DIFF
--- a/Core/Inc/wmm.h
+++ b/Core/Inc/wmm.h
@@ -3,7 +3,7 @@
 
 #include <stdint.h>
 
-#define WMM_EPOCH		2020.0f
+#define WMM_EPOCH		2025.0f
 
 typedef struct
 {


### PR DESCRIPTION
`WMM.COF` was updated to latest, but `WMM_EPOCH` constant did not change. As result we may see slight deviations.

Used [noaa.gov](https://www.ngdc.noaa.gov/geomag/calculators/mobileDeclination.shtml#WMM) to verify results